### PR TITLE
Add warning when trying to changes highest non-boost P-State frequency.

### DIFF
--- a/AmdMsrTweaker.cpp
+++ b/AmdMsrTweaker.cpp
@@ -14,6 +14,7 @@
 using std::cout;
 using std::cerr;
 using std::endl;
+using std::string;
 
 
 void PrintInfo(const Info& info);
@@ -54,7 +55,34 @@ int main(int argc, const char* argv[])
 				return 3;
 			}
 
-			worker.ApplyChanges();
+			bool noWarning = false;
+			for (int i = 1; i < argc; i++)
+			{
+				if (strcmp(argv[i], "--no-warn") == 0)
+				{
+					noWarning = true;
+					break;
+				}
+			}
+
+			if (!worker.ApplyChanges(noWarning))
+			{
+				cout << "WARNING: Trying to change clock for highest non-boost";
+				cout << " P-state. This can cause issues with the graphical ";
+				cout << "system of Windows and render the system unusable ";
+				cout << "until a reboot. (Use --no-warn to disable this ";
+				cout << "warning)" << endl;
+				cout << "Do you want to proceed? [yN]" << endl;
+				int answer = _getch();
+				if (answer == 'y' || answer == 'Y')
+				{
+					worker.ApplyChanges(true);
+				}
+				else
+				{
+					return 4;
+				}
+			}
 		}
 		else
 		{

--- a/Worker.h
+++ b/Worker.h
@@ -24,7 +24,7 @@ public:
 
 	bool ParseParams(int argc, const char* argv[]);
 
-	void ApplyChanges();
+	bool ApplyChanges(bool allowHighestNonBoostChange);
 
 
 private:


### PR DESCRIPTION
As promised a patch to add a warning message. My C++ is very rusty (haven't used it since university), so feel free to reject it or base your own implementation on my code.
